### PR TITLE
Added optional custom http.Client to HttpTransport

### DIFF
--- a/barrister.go
+++ b/barrister.go
@@ -668,7 +668,11 @@ type HttpTransport struct {
 	// Optional hook to invoke before/after requests
 	Hook HttpHook
 
+	// Optional custom HTTP client to be used instead of the default empty one.
+	Client *http.Client
+
 	// Optional CookieJar - useful if endpoint uses session cookies
+	// Deprecated by custom Client option. If you need to provide CookieJar, provide a &http.Client{Jar: YourCookie}
 	Jar http.CookieJar
 }
 
@@ -699,7 +703,11 @@ func (t *HttpTransport) Send(in []byte) ([]byte, error) {
 		t.Hook.Before(req, in)
 	}
 
-	client := &http.Client{}
+	client := t.Client
+	if client == nil {
+		client = &http.Client{}
+	}
+
 	if t.Jar != nil {
 		client.Jar = t.Jar
 	}


### PR DESCRIPTION
In order to be able to support custom timeouts, for example, `HttpTransport` now supports `http.Client` to be provided.

This makes `Jar` option unneeded which now is marked as deprecated and should be removed in the next major version.