### PR TITLE
Fix generated enum type declarations

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -120,13 +120,9 @@ func (g *generateGo) generateEnum(b *bytes.Buffer, enumName string) {
 	goName := capitalizeAndStripMatchingPkg(enumName, g.pkgName)
 	line(b, 0, fmt.Sprintf("type %s string", goName))
 	line(b, 0, "const (")
-	for x, val := range vals {
-		typeStr := ""
-		if x == 0 {
-			typeStr = goName
-		}
+	for _, val := range vals {
 		line(b, 1, fmt.Sprintf("%s%s %s = \"%s\"",
-			goName, capitalize(val.Value), typeStr, val.Value))
+			goName, capitalize(val.Value), goName, val.Value))
 	}
 	line(b, 0, ")\n")
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,0 +1,45 @@
+package barrister
+
+import (
+	"testing"
+	"fmt"
+	"bytes"
+)
+
+func TestGenerateEnum(t *testing.T) {
+	for i, tc := range []struct {
+		enums map[string][]EnumValue
+		res []byte
+	}{
+		{
+			map[string][]EnumValue{
+				"asdf": {EnumValue{Value: "foo"}},
+			},
+			[]byte("type Asdf string\nconst (\n	AsdfFoo Asdf = \"foo\"\n)\n\n"),
+	},
+		{
+			map[string][]EnumValue{
+				"asdf": {EnumValue{Value: "foo"}, EnumValue{Value: "bar"}},
+			},
+			[]byte("type Asdf string\nconst (\n	AsdfFoo Asdf = \"foo\"\n	AsdfBar Asdf = \"bar\"\n)\n\n"),
+		},
+	} {
+		tc := tc
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			g := &generateGo{
+				idl: &Idl{
+					enums: tc.enums,
+				},
+			}
+
+			res := &bytes.Buffer{}
+			g.generateEnum(res, "asdf")
+
+			if string(res.Bytes()) != string(tc.res) {
+				t.Errorf("Expected %s, got %s", tc.res, res.Bytes())
+			}
+		})
+	}
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,26 +1,22 @@
 package barrister
 
 import (
-	"testing"
-	"fmt"
 	"bytes"
+	"fmt"
+	"testing"
 )
 
 func TestGenerateEnum(t *testing.T) {
 	for i, tc := range []struct {
-		enums map[string][]EnumValue
-		res []byte
+		enums []EnumValue
+		res   []byte
 	}{
 		{
-			map[string][]EnumValue{
-				"asdf": {EnumValue{Value: "foo"}},
-			},
+			[]EnumValue{EnumValue{Value: "foo"}},
 			[]byte("type Asdf string\nconst (\n	AsdfFoo Asdf = \"foo\"\n)\n\n"),
-	},
+		},
 		{
-			map[string][]EnumValue{
-				"asdf": {EnumValue{Value: "foo"}, EnumValue{Value: "bar"}},
-			},
+			[]EnumValue{EnumValue{Value: "foo"}, EnumValue{Value: "bar"}},
 			[]byte("type Asdf string\nconst (\n	AsdfFoo Asdf = \"foo\"\n	AsdfBar Asdf = \"bar\"\n)\n\n"),
 		},
 	} {
@@ -30,7 +26,9 @@ func TestGenerateEnum(t *testing.T) {
 
 			g := &generateGo{
 				idl: &Idl{
-					enums: tc.enums,
+					enums: map[string][]EnumValue{
+						"asdf": tc.enums,
+					},
 				},
 			}
 


### PR DESCRIPTION
The generated enums do not have the correct type. `barrister-go` generates constants of the form:
```
type MyString string
const (
    MyStringOneString MyString = "onestring"
    MyStringTwoString          = "twostring"
)
```
However only the first constant is of the correct type, as demonstrated [in this playground](https://play.golang.org/p/gTUSmOCSDxe). This PR adds a test case and declares the type on each line.